### PR TITLE
Fixed test exec error: lrn_ristretto_layer.cpp:16] LRN layer only supports minifloat

### DIFF
--- a/src/caffe/test/test_layer_factory.cpp
+++ b/src/caffe/test/test_layer_factory.cpp
@@ -42,6 +42,9 @@ TYPED_TEST(LayerFactoryTest, TestCreateLayer) {
       continue;
 #endif  // USE_LEVELDB
     }
+    if (iter->first == "LRNRistretto") {
+      layer_param.mutable_quantization_param()->set_precision(caffe::QuantizationParameter_Precision_MINIFLOAT);
+    }
     layer_param.set_type(iter->first);
     layer = LayerRegistry<Dtype>::CreateLayer(layer_param);
     EXPECT_EQ(iter->first, layer->type());


### PR DESCRIPTION
I fixed test execution error for test_layer_factory.cpp by applying the fix mentioned here https://groups.google.com/forum/#!topic/ristretto-users/iPFJmt2ufB0